### PR TITLE
회원도메인 구현

### DIFF
--- a/src/main/java/com/example/wegather/global/Message.java
+++ b/src/main/java/com/example/wegather/global/Message.java
@@ -4,5 +4,6 @@ public class Message {
   public static class Error {
     public static final String INTEREST_NAME_ALREADY_EXISTS = "관심사 이름이 이미 존재합니다.";
     public static final String INTEREST_NOT_FOUND = "해당 관심사를 찾을 수 없습니다.";
+    public static final String USERNAME_RULE_VIOLATION = "회원 아이디는 4-12자 사이의 영문 또는 숫자여야 합니다.";
   }
 }

--- a/src/main/java/com/example/wegather/global/Message.java
+++ b/src/main/java/com/example/wegather/global/Message.java
@@ -4,7 +4,9 @@ public class Message {
   public static class Error {
     public static final String INTEREST_NAME_ALREADY_EXISTS = "관심사 이름이 이미 존재합니다.";
     public static final String INTEREST_NOT_FOUND = "해당 관심사를 찾을 수 없습니다.";
-    public static final String USERNAME_RULE_VIOLATION = "회원 아이디는 4-12자 사이의 영문 또는 숫자여야 합니다.";
+    public static final String MEMBER_NOT_FOUND = "해당 회원을 찾을 수 없습니다.";
+    public static final String USERNAME_DUPLICATED = "중복된 회원 ID 입니다.";
+    public static final String USERNAME_RULE_VIOLATION = "회원 아이디는 4-12자 사이의 영문 소문자 또는 숫자여야 합니다.";
     public static final String PASSWORD_RULE_VIOLATION = "비밀번호는 4-12자 사이의 영문 대소문자 또는 숫자여야합니다.";
     public static final String PHONE_NUMBER_RULE_VIOLATION = "올바른 전화번호를 입력해주세요.";
     public static final String STREET_ADDRESS_MUST_NOT_EMPTY = "도로명주소는 값이 비어있을 수 없습니다.";

--- a/src/main/java/com/example/wegather/global/Message.java
+++ b/src/main/java/com/example/wegather/global/Message.java
@@ -6,5 +6,6 @@ public class Message {
     public static final String INTEREST_NOT_FOUND = "해당 관심사를 찾을 수 없습니다.";
     public static final String USERNAME_RULE_VIOLATION = "회원 아이디는 4-12자 사이의 영문 또는 숫자여야 합니다.";
     public static final String PASSWORD_RULE_VIOLATION = "비밀번호는 4-12자 사이의 영문 대소문자 또는 숫자여야합니다.";
+    public static final String PHONE_NUMBER_RULE_VIOLATION = "올바른 전화번호를 입력해주세요.";
   }
 }

--- a/src/main/java/com/example/wegather/global/Message.java
+++ b/src/main/java/com/example/wegather/global/Message.java
@@ -5,5 +5,6 @@ public class Message {
     public static final String INTEREST_NAME_ALREADY_EXISTS = "관심사 이름이 이미 존재합니다.";
     public static final String INTEREST_NOT_FOUND = "해당 관심사를 찾을 수 없습니다.";
     public static final String USERNAME_RULE_VIOLATION = "회원 아이디는 4-12자 사이의 영문 또는 숫자여야 합니다.";
+    public static final String PASSWORD_RULE_VIOLATION = "비밀번호는 4-12자 사이의 영문 대소문자 또는 숫자여야합니다.";
   }
 }

--- a/src/main/java/com/example/wegather/global/Message.java
+++ b/src/main/java/com/example/wegather/global/Message.java
@@ -7,5 +7,6 @@ public class Message {
     public static final String USERNAME_RULE_VIOLATION = "회원 아이디는 4-12자 사이의 영문 또는 숫자여야 합니다.";
     public static final String PASSWORD_RULE_VIOLATION = "비밀번호는 4-12자 사이의 영문 대소문자 또는 숫자여야합니다.";
     public static final String PHONE_NUMBER_RULE_VIOLATION = "올바른 전화번호를 입력해주세요.";
+    public static final String STREET_ADDRESS_MUST_NOT_EMPTY = "도로명주소는 값이 비어있을 수 없습니다.";
   }
 }

--- a/src/main/java/com/example/wegather/global/vo/Address.java
+++ b/src/main/java/com/example/wegather/global/vo/Address.java
@@ -1,21 +1,30 @@
 package com.example.wegather.global.vo;
 
+import static com.example.wegather.global.Message.Error.STREET_ADDRESS_MUST_NOT_EMPTY;
+
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 @Getter
 public class Address {
-  private final String value;
+  private final String streetAddress; // 도로명주소
+  private final Double longitude;   // 경도
+  private final Double latitude;   // 위도
 
-  private Address(String value) {
-    this.value = value;
+  public Address(String streetAddress, Double longitude, Double latitude) {
+    validateAddress(streetAddress, longitude, latitude);
+    this.streetAddress = streetAddress;
+    this.longitude = longitude;
+    this.latitude = latitude;
   }
 
-  public Address of(String value) {
-    validate(value);
-    return new Address(value);
+  public static Address of(String streetAddress, Double longitude, Double latitude) {
+    return new Address(streetAddress, longitude, latitude);
   }
 
-  void validate(String value) {
-
+  void validateAddress(String streetAddress, Double longitude, Double latitude) {
+    if (!StringUtils.hasText(streetAddress)) {
+      throw new IllegalArgumentException(STREET_ADDRESS_MUST_NOT_EMPTY);
+    }
   }
 }

--- a/src/main/java/com/example/wegather/global/vo/Address.java
+++ b/src/main/java/com/example/wegather/global/vo/Address.java
@@ -2,14 +2,19 @@ package com.example.wegather.global.vo;
 
 import static com.example.wegather.global.Message.Error.STREET_ADDRESS_MUST_NOT_EMPTY;
 
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
 @Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address {
-  private final String streetAddress; // 도로명주소
-  private final Double longitude;   // 경도
-  private final Double latitude;   // 위도
+  private String streetAddress; // 도로명주소
+  private Double longitude;   // 경도
+  private Double latitude;   // 위도
 
   public Address(String streetAddress, Double longitude, Double latitude) {
     validateAddress(streetAddress, longitude, latitude);

--- a/src/main/java/com/example/wegather/global/vo/Address.java
+++ b/src/main/java/com/example/wegather/global/vo/Address.java
@@ -1,0 +1,21 @@
+package com.example.wegather.global.vo;
+
+import lombok.Getter;
+
+@Getter
+public class Address {
+  private final String value;
+
+  private Address(String value) {
+    this.value = value;
+  }
+
+  public Address of(String value) {
+    validate(value);
+    return new Address(value);
+  }
+
+  void validate(String value) {
+
+  }
+}

--- a/src/main/java/com/example/wegather/global/vo/Image.java
+++ b/src/main/java/com/example/wegather/global/vo/Image.java
@@ -1,0 +1,17 @@
+package com.example.wegather.global.vo;
+
+
+import lombok.Getter;
+
+@Getter
+public class Image {
+  private final String value;
+
+  private Image(String value) {
+    this.value = value;
+  }
+
+  public static Image of(String value) {
+    return new Image(value);
+  }
+}

--- a/src/main/java/com/example/wegather/global/vo/PhoneNumber.java
+++ b/src/main/java/com/example/wegather/global/vo/PhoneNumber.java
@@ -3,12 +3,17 @@ package com.example.wegather.global.vo;
 import static com.example.wegather.global.Message.Error.PHONE_NUMBER_RULE_VIOLATION;
 
 import java.util.regex.Pattern;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PhoneNumber {
   private static final Pattern PHONE_NUMBER_RULE = Pattern.compile("^01([0|1|6|7|8|9])-?(\\d{3,4})-?(\\d{4})$");
-  private final String value;
+  private String value;
 
   private PhoneNumber(String value) {
     validatePhoneNumberRule(value);

--- a/src/main/java/com/example/wegather/global/vo/PhoneNumber.java
+++ b/src/main/java/com/example/wegather/global/vo/PhoneNumber.java
@@ -1,21 +1,27 @@
 package com.example.wegather.global.vo;
 
+import static com.example.wegather.global.Message.Error.PHONE_NUMBER_RULE_VIOLATION;
+
+import java.util.regex.Pattern;
 import lombok.Getter;
 
 @Getter
 public class PhoneNumber {
+  private static final Pattern PHONE_NUMBER_RULE = Pattern.compile("^01([0|1|6|7|8|9])-?(\\d{3,4})-?(\\d{4})$");
   private final String value;
 
   private PhoneNumber(String value) {
+    validatePhoneNumberRule(value);
     this.value = value;
   }
 
-  public PhoneNumber of(String value) {
-    validate(value);
+  public static PhoneNumber of(String value) {
     return new PhoneNumber(value);
   }
 
-  void validate(String value) {
-
+  void validatePhoneNumberRule(String value) {
+    if (!PHONE_NUMBER_RULE.matcher(value).matches()) {
+      throw new IllegalArgumentException(PHONE_NUMBER_RULE_VIOLATION);
+    }
   }
 }

--- a/src/main/java/com/example/wegather/global/vo/PhoneNumber.java
+++ b/src/main/java/com/example/wegather/global/vo/PhoneNumber.java
@@ -1,0 +1,21 @@
+package com.example.wegather.global.vo;
+
+import lombok.Getter;
+
+@Getter
+public class PhoneNumber {
+  private final String value;
+
+  private PhoneNumber(String value) {
+    this.value = value;
+  }
+
+  public PhoneNumber of(String value) {
+    validate(value);
+    return new PhoneNumber(value);
+  }
+
+  void validate(String value) {
+
+  }
+}

--- a/src/main/java/com/example/wegather/member/domain/Member.java
+++ b/src/main/java/com/example/wegather/member/domain/Member.java
@@ -4,6 +4,7 @@ import com.example.wegather.global.BaseTimeEntity;
 import com.example.wegather.global.vo.Address;
 import com.example.wegather.global.vo.Image;
 import com.example.wegather.global.vo.PhoneNumber;
+import com.example.wegather.member.domain.vo.Interests;
 import com.example.wegather.member.domain.vo.MemberType;
 import com.example.wegather.member.domain.vo.Password;
 import com.example.wegather.member.domain.vo.Username;
@@ -51,5 +52,8 @@ public class Member extends BaseTimeEntity {
   @Embedded
   @AttributeOverride(name = "value", column = @Column(name = "profile_image"))
   private Image profileImage;
+  @Embedded
+  @AttributeOverride(name = "value", column = @Column(name = "interests"))
+  Interests interests;
 }
 

--- a/src/main/java/com/example/wegather/member/domain/Member.java
+++ b/src/main/java/com/example/wegather/member/domain/Member.java
@@ -19,12 +19,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 @Entity
 public class Member extends BaseTimeEntity {
   @Id

--- a/src/main/java/com/example/wegather/member/domain/Member.java
+++ b/src/main/java/com/example/wegather/member/domain/Member.java
@@ -1,6 +1,19 @@
 package com.example.wegather.member.domain;
 
+import com.example.wegather.global.BaseTimeEntity;
+import com.example.wegather.global.vo.Address;
+import com.example.wegather.global.vo.Image;
+import com.example.wegather.global.vo.PhoneNumber;
+import com.example.wegather.member.domain.vo.MemberType;
+import com.example.wegather.member.domain.vo.Password;
+import com.example.wegather.member.domain.vo.Username;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import lombok.AccessLevel;
@@ -12,9 +25,31 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-public class Member {
+public class Member extends BaseTimeEntity {
   @Id
   @GeneratedValue
   private Long id;
+  @Embedded
+  @AttributeOverride(name = "value", column = @Column(name = "username"))
+  private Username username;
+  @Embedded
+  @AttributeOverride(name = "value", column = @Column(name = "password"))
+  private Password password;
+  private String name;
+  @Embedded
+  @AttributeOverride(name = "value", column = @Column(name = "phone_number"))
+  private PhoneNumber phoneNumber;
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "streetAddress", column = @Column(name = "street_address")),
+      @AttributeOverride(name = "longitude", column = @Column(name = "longitude")),
+      @AttributeOverride(name = "latitude", column = @Column(name = "latitude"))
+  })
+  private Address address;
+  @Enumerated(EnumType.STRING)
+  private MemberType memberType;
+  @Embedded
+  @AttributeOverride(name = "value", column = @Column(name = "profile_image"))
+  private Image profileImage;
 }
 

--- a/src/main/java/com/example/wegather/member/domain/Member.java
+++ b/src/main/java/com/example/wegather/member/domain/Member.java
@@ -1,0 +1,20 @@
+package com.example.wegather.member.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Member {
+  @Id
+  @GeneratedValue
+  private Long id;
+}
+

--- a/src/main/java/com/example/wegather/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/wegather/member/domain/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.example.wegather.member.domain;
+
+import com.example.wegather.member.domain.vo.Username;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+  boolean existsByUsername(Username username);
+}

--- a/src/main/java/com/example/wegather/member/domain/MemberService.java
+++ b/src/main/java/com/example/wegather/member/domain/MemberService.java
@@ -1,0 +1,54 @@
+package com.example.wegather.member.domain;
+
+import static com.example.wegather.global.Message.Error.MEMBER_NOT_FOUND;
+import static com.example.wegather.global.Message.Error.USERNAME_DUPLICATED;
+
+import com.example.wegather.global.vo.Address;
+import com.example.wegather.global.vo.Image;
+import com.example.wegather.global.vo.PhoneNumber;
+import com.example.wegather.member.domain.vo.Password;
+import com.example.wegather.member.domain.vo.Username;
+import com.example.wegather.member.dto.JoinMemberRequest;
+import com.example.wegather.member.dto.MemberDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+  private final MemberRepository memberRepository;
+
+  public Member joinMember(JoinMemberRequest request) {
+    if (memberRepository.existsByUsername(Username.of(request.getUsername()))) {
+      throw new IllegalArgumentException(USERNAME_DUPLICATED);
+    }
+
+    return memberRepository.save(Member.builder()
+            .username(Username.of(request.getUsername()))
+            .password(Password.of(request.getPassword()))
+            .name(request.getName())
+            .phoneNumber(PhoneNumber.of(request.getPhoneNumber()))
+            .address(Address.of(request.getStreetAddress()
+                , request.getLongitude()
+                , request.getLatitude()))
+            .memberType(request.getMemberType())
+            .profileImage(Image.of(request.getProfileImage()))
+        .build());
+  }
+
+  public List<Member> getAllInterests() {
+    return memberRepository.findAll();
+  }
+
+  public Member getMember(Long id) {
+    return memberRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException(MEMBER_NOT_FOUND));
+  }
+
+  public void deleteMember(Long id) {
+    memberRepository.deleteById(id);
+  }
+}

--- a/src/main/java/com/example/wegather/member/domain/vo/Interests.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Interests.java
@@ -1,4 +1,4 @@
-package com.example.wegather.global.vo;
+package com.example.wegather.member.domain.vo;
 
 
 import javax.persistence.Embeddable;
@@ -9,14 +9,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Image {
+public class Interests {
   private String value;
 
-  private Image(String value) {
+  private Interests(String value) {
     this.value = value;
   }
 
-  public static Image of(String value) {
-    return new Image(value);
+  public static Interests of(String value) {
+    return new Interests(value);
   }
 }

--- a/src/main/java/com/example/wegather/member/domain/vo/MemberType.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/MemberType.java
@@ -1,0 +1,11 @@
+package com.example.wegather.member.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberType {
+  USER("유저"), ADMIN("관리자");
+  private final String describe;
+}

--- a/src/main/java/com/example/wegather/member/domain/vo/Password.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Password.java
@@ -3,12 +3,17 @@ package com.example.wegather.member.domain.vo;
 import static com.example.wegather.global.Message.Error.PASSWORD_RULE_VIOLATION;
 
 import java.util.regex.Pattern;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Password {
   private static final Pattern PASSWORD_RULE = Pattern.compile("^[A-Za-z0-9]{4,12}$");
-  private final String value;
+  private String value;
 
   private Password(String value) {
     validatePasswordRule(value);

--- a/src/main/java/com/example/wegather/member/domain/vo/Password.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Password.java
@@ -1,0 +1,21 @@
+package com.example.wegather.member.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public class Password {
+  private final String value;
+
+  private Password(String value) {
+    this.value = value;
+  }
+
+  public Password of(String value) {
+    validate(value);
+    return new Password(value);
+  }
+
+  void validate(String value) {
+
+  }
+}

--- a/src/main/java/com/example/wegather/member/domain/vo/Password.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Password.java
@@ -1,21 +1,34 @@
 package com.example.wegather.member.domain.vo;
 
+import static com.example.wegather.global.Message.Error.PASSWORD_RULE_VIOLATION;
+
+import java.util.regex.Pattern;
 import lombok.Getter;
 
 @Getter
 public class Password {
+  private static final Pattern PASSWORD_RULE = Pattern.compile("^[A-Za-z0-9]{4,12}$");
   private final String value;
 
   private Password(String value) {
+    validatePasswordRule(value);
     this.value = value;
   }
 
-  public Password of(String value) {
-    validate(value);
+  /**
+   * 비밀번호를 생성합니다.
+   * 영문 대소문자, 숫자로 이루어진 4자 - 12자 사이의 문자
+   * @throws IllegalArgumentException 비밀번호 규칙에 맞지 않을 경우 예외를 던집니다.
+   * @param value
+   * @return
+   */
+  public static Password of(String value) {
     return new Password(value);
   }
 
-  void validate(String value) {
-
+  void validatePasswordRule(String value) {
+    if (!PASSWORD_RULE.matcher(value).matches()) {
+      throw new IllegalArgumentException(PASSWORD_RULE_VIOLATION);
+    }
   }
 }

--- a/src/main/java/com/example/wegather/member/domain/vo/Username.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Username.java
@@ -1,0 +1,33 @@
+package com.example.wegather.member.domain.vo;
+
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+@Getter
+public class Username {
+
+  private static final String USERNAME_MUST_GREATER_THAN_FIVE = "사용자 아이디는 5글자 이상이어야합니다.";
+  private final String value;
+
+  private Username(String value) {
+    validateNamingRule(value);
+    this.value = value;
+  }
+
+  public Username of(String value) {
+    return new Username(value);
+  }
+
+  /**
+   * username 네이밍 규칙 유효성 검사
+   * 1. 값이 없으면 안됩니다.
+   * 2. 5글자 이상이어야 합니다.
+   * @throws IllegalArgumentException 사용자 아이디가 5글자 아싱아 아닐때 예외를 던집니다.
+   * @param value
+   */
+  void validateNamingRule(String value) {
+    if (!StringUtils.hasText(value) && value.length() > 5) {
+      throw new IllegalArgumentException(USERNAME_MUST_GREATER_THAN_FIVE);
+    }
+  }
+}

--- a/src/main/java/com/example/wegather/member/domain/vo/Username.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Username.java
@@ -3,12 +3,17 @@ package com.example.wegather.member.domain.vo;
 import static com.example.wegather.global.Message.Error.USERNAME_RULE_VIOLATION;
 
 import java.util.regex.Pattern;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Username {
   private static final Pattern USERNAME_RULE = Pattern.compile("^[a-z0-9]{4,12}$");
-  private final String value;
+  private String value;
 
   private Username(String value) {
     validateNamingRule(value);

--- a/src/main/java/com/example/wegather/member/domain/vo/Username.java
+++ b/src/main/java/com/example/wegather/member/domain/vo/Username.java
@@ -1,12 +1,13 @@
 package com.example.wegather.member.domain.vo;
 
+import static com.example.wegather.global.Message.Error.USERNAME_RULE_VIOLATION;
+
+import java.util.regex.Pattern;
 import lombok.Getter;
-import org.springframework.util.StringUtils;
 
 @Getter
 public class Username {
-
-  private static final String USERNAME_MUST_GREATER_THAN_FIVE = "사용자 아이디는 5글자 이상이어야합니다.";
+  private static final Pattern USERNAME_RULE = Pattern.compile("^[a-z0-9]{4,12}$");
   private final String value;
 
   private Username(String value) {
@@ -14,20 +15,19 @@ public class Username {
     this.value = value;
   }
 
-  public Username of(String value) {
+  /**
+   * username 을 생성합니다.버
+   * 영문소문자, 숫자로 이루어진 4자 - 12자 사이의 글자
+   * @throws IllegalArgumentException 회원 아이디 규칙에 맞지 않을 경우 예외를 던집니다.
+   * @param value
+   */
+  public static Username of(String value) {
     return new Username(value);
   }
 
-  /**
-   * username 네이밍 규칙 유효성 검사
-   * 1. 값이 없으면 안됩니다.
-   * 2. 5글자 이상이어야 합니다.
-   * @throws IllegalArgumentException 사용자 아이디가 5글자 아싱아 아닐때 예외를 던집니다.
-   * @param value
-   */
   void validateNamingRule(String value) {
-    if (!StringUtils.hasText(value) && value.length() > 5) {
-      throw new IllegalArgumentException(USERNAME_MUST_GREATER_THAN_FIVE);
+    if (!USERNAME_RULE.matcher(value).matches()) {
+      throw new IllegalArgumentException(USERNAME_RULE_VIOLATION);
     }
   }
 }

--- a/src/main/java/com/example/wegather/member/dto/JoinMemberRequest.java
+++ b/src/main/java/com/example/wegather/member/dto/JoinMemberRequest.java
@@ -1,0 +1,27 @@
+package com.example.wegather.member.dto;
+
+import com.example.wegather.member.domain.vo.MemberType;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class JoinMemberRequest {
+  @NotEmpty
+  private String username;
+  @NotEmpty
+  private String password;
+  @NotEmpty
+  private String name;
+  private String phoneNumber;
+  private String streetAddress;
+  private Double longitude;
+  private Double latitude;
+  @NotNull
+  private MemberType memberType;
+  private String profileImage;
+}

--- a/src/main/java/com/example/wegather/member/dto/MemberDto.java
+++ b/src/main/java/com/example/wegather/member/dto/MemberDto.java
@@ -1,0 +1,39 @@
+package com.example.wegather.member.dto;
+
+import com.example.wegather.member.domain.Member;
+import com.example.wegather.member.domain.vo.MemberType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberDto {
+  private Long id;
+  private String username;
+  private String name;
+  private String phoneNumber;
+  private String streetAddress;
+  private Double longitude;
+  private Double latitude;
+  private MemberType memberType;
+  private String profileImage;
+  private List<String> interests = new ArrayList<>();
+
+  public static MemberDto from(Member member) {
+    return MemberDto.builder()
+        .id(member.getId())
+        .username(member.getUsername().getValue())
+        .name(member.getName())
+        .phoneNumber(member.getPhoneNumber().getValue())
+        .streetAddress(member.getAddress().getStreetAddress())
+        .longitude(member.getAddress().getLongitude())
+        .latitude(member.getAddress().getLatitude())
+        .memberType(member.getMemberType())
+        .profileImage(member.getProfileImage().getValue())
+        .build();
+  }
+}

--- a/src/main/java/com/example/wegather/member/web/MemberController.java
+++ b/src/main/java/com/example/wegather/member/web/MemberController.java
@@ -1,0 +1,71 @@
+package com.example.wegather.member.web;
+
+import com.example.wegather.member.domain.MemberService;
+import com.example.wegather.member.dto.JoinMemberRequest;
+import com.example.wegather.member.dto.MemberDto;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+  /**
+   * 회원을 새로 추가합니다.
+   * @throws IllegalArgumentException
+   *           - 회원 username 이 중복된 경우
+   *           - username, password, phoneNumber, address 등이 형식에 맞지 않는 경우
+   * @param request 회원가입시 입력되는 회원정보
+   * @return 생성된 회원
+   */
+  @PostMapping
+  public ResponseEntity<MemberDto> createMember(@Valid @RequestBody JoinMemberRequest request) {
+    MemberDto memberDto = MemberDto.from(memberService.joinMember(request));
+    return ResponseEntity.created(URI.create("/members/" + memberDto.getId()))
+        .body(memberDto);
+  }
+
+  /**
+   * 전체 회원을 조회합니다.  //TODO: 페이징 넣기
+   * @return 전체 관심사 목록
+   */
+  @GetMapping
+  public ResponseEntity<List<MemberDto>> readAllMember() {
+    return ResponseEntity.ok(memberService.getAllInterests()
+        .stream().map(MemberDto::from).collect(Collectors.toList()));
+  }
+
+  /**
+   * id로 관심사를 조회합니다.
+   * @throws IllegalArgumentException id에 해당하는 관심사가 없는 경우 예외를 던집니다.
+   * @param id
+   * @return
+   */
+  @GetMapping("/{id}")
+  public ResponseEntity<MemberDto> readMemberById(@PathVariable Long id) {
+    return ResponseEntity.ok(MemberDto.from(memberService.getMember(id)));
+  }
+
+  /**
+   * id로 관심사를 삭제합니다.
+   * @param id
+   */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteMemberById(@PathVariable Long id) {
+    memberService.deleteMember(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/resources/truncate.sql
+++ b/src/main/resources/truncate.sql
@@ -1,1 +1,3 @@
 TRUNCATE TABLE interest;
+TRUNCATE TABLE member;
+

--- a/src/test/java/com/example/wegather/global/vo/AddressTest.java
+++ b/src/test/java/com/example/wegather/global/vo/AddressTest.java
@@ -1,0 +1,37 @@
+package com.example.wegather.global.vo;
+
+import static com.example.wegather.global.Message.Error.STREET_ADDRESS_MUST_NOT_EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AddressTest {
+  @Test
+  @DisplayName("주소 생성에 성공합니다.")
+  void createAddressSuccessfully() {
+    String streetAddress = "서울특별시 남구 백송대로 401번길 9";
+    Double longitude = 35.97664845766847;
+    Double latitude = 126.99597295767953;
+
+    Address result = Address.of(streetAddress, longitude, latitude);
+
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  @DisplayName("도로명주소가 비어있어서 주소 생성에 실패합니다.")
+  void createAddressFailBecauseOfEmpty() {
+    // given
+    String streetAddress = "";
+    Double longitude = 35.97664845766847;
+    Double latitude = 126.99597295767953;
+
+    // when // then
+    assertThatThrownBy(() -> {
+      Address result = Address.of(streetAddress, longitude, latitude);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(STREET_ADDRESS_MUST_NOT_EMPTY);
+  }
+}

--- a/src/test/java/com/example/wegather/global/vo/PhoneNumberTest.java
+++ b/src/test/java/com/example/wegather/global/vo/PhoneNumberTest.java
@@ -1,0 +1,33 @@
+package com.example.wegather.global.vo;
+
+import static com.example.wegather.global.Message.Error.PHONE_NUMBER_RULE_VIOLATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PhoneNumberTest {
+  @Test
+  @DisplayName("전화번호 생성에 성공합니다.")
+  void createPhoneNumberSuccessfully() {
+    String phoneNumber = "010-1234-1234";
+
+    PhoneNumber result = PhoneNumber.of(phoneNumber);
+
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  @DisplayName("전화번호 형식에 맞지 않아 생성에 실패합니다.")
+  void createPhoneNumberFailBecauseOfLessThanFour() {
+    // given
+    String phoneNumber = "010-11111-42323";
+
+    // when // then
+    assertThatThrownBy(() -> {
+      PhoneNumber result = PhoneNumber.of(phoneNumber);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(PHONE_NUMBER_RULE_VIOLATION);
+  }
+}

--- a/src/test/java/com/example/wegather/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/wegather/integration/MemberIntegrationTest.java
@@ -1,13 +1,170 @@
 package com.example.wegather.integration;
 
+import static com.example.wegather.member.domain.vo.MemberType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.wegather.member.domain.vo.MemberType;
+import com.example.wegather.member.dto.JoinMemberRequest;
+import com.example.wegather.member.dto.MemberDto;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("회원 통합테스트")
 public class MemberIntegrationTest extends IntegrationTest {
 
-  @Test
-  void test() {
+  MemberDto member01;
+  MemberDto member02;
+  MemberDto member03;
 
+  @BeforeEach
+  void init() {
+    member01 = insertMember("test01", "김지유", USER);
+    member02 = insertMember("test02", "김진주", USER);
+    member03 = insertMember("test03", "박세미", USER);
+  }
+
+  @Test
+  @DisplayName("회원을 생성합니다.")
+  void joinMemberSuccessfully() {
+    JoinMemberRequest request = JoinMemberRequest.builder()
+        .username("test1")
+        .password("password")
+        .name("김지유")
+        .phoneNumber("010-1234-1234")
+        .streetAddress("서울시 강남구 백양대로 123-12")
+        .longitude(123.12312)
+        .latitude(23.131)
+        .memberType(USER)
+        .profileImage("/image/test/1")
+        .build();
+
+    ExtractableResponse<Response> response = RestAssured
+        .given().log().all()
+        .body(request)
+        .contentType(ContentType.JSON)
+        .when().post("/members")
+        .then().log().all()
+        .extract();
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_CREATED);
+    MemberDto memberDto = response.body().as(MemberDto.class);
+    assertThat(memberDto)
+        .usingRecursiveComparison()
+        .ignoringFields("id")
+        .ignoringActualNullFields()
+        .isEqualTo(request);
+  }
+
+  @Test
+  @DisplayName("회원 ID가 이미 존재하는 경우 예외를 던집니다.")
+  void joinMemberFailWhenUsernameAlreadyExists() {
+    // given
+    String username = "duplicate1";
+    insertMember(username, "김지유", USER);
+
+    JoinMemberRequest request = JoinMemberRequest.builder()
+        .username(username)
+        .password("password")
+        .name("김지유")
+        .phoneNumber("010-1234-1234")
+        .streetAddress("서울시 강남구 백양대로 123-12")
+        .longitude(123.12312)
+        .latitude(23.131)
+        .memberType(USER)
+        .profileImage("/image/test/1")
+        .build();
+
+    // when
+    ExtractableResponse<Response> response = RestAssured
+        .given().log().all()
+        .body(request)
+        .contentType(ContentType.JSON)
+        .when().post("/members")
+        .then().log().all()
+        .extract();
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("전체 회원을 조회합니다.")
+  void readAllMembersSuccessfully() {
+    // given
+    // when
+    ExtractableResponse<Response> response = RestAssured
+        .given().log().all()
+        .contentType(ContentType.JSON)
+        .when().get("/members")
+        .then().log().all()
+        .extract();
+
+    //then
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+    List<MemberDto> list = response.body().jsonPath().getList(".", MemberDto.class);
+    assertThat(list).hasSize(3);
+    assertThat(list).usingRecursiveComparison().isEqualTo(List.of(member01, member02, member03));
+  }
+
+  @Test
+  @DisplayName("id로 회원을 조회합니다.")
+  void readOneMemberByIdSuccessfully() {
+    // given
+    // when
+    ExtractableResponse<Response> response = RestAssured
+        .given().log().all()
+        .pathParam("id", member01.getId())
+        .contentType(ContentType.JSON)
+        .when().get("/members/{id}")
+        .then().log().all()
+        .extract();
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+    assertThat(response.body().as(MemberDto.class))
+        .usingRecursiveComparison().isEqualTo(member01);
+  }
+
+  @Test
+  @DisplayName("id로 관심사를 삭제합니다.")
+  void deleteMemberByIdSuccessfully() {
+    // given
+    // when
+    ExtractableResponse<Response> response = RestAssured
+        .given().log().all()
+        .pathParam("id", member01.getId())
+        .contentType(ContentType.JSON)
+        .when().delete("/members/{id}")
+        .then().log().all()
+        .extract();
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+  }
+
+
+  private MemberDto insertMember(String username, String name, MemberType memberType) {
+    JoinMemberRequest request = JoinMemberRequest.builder()
+        .username(username)
+        .password("password")
+        .name(name)
+        .phoneNumber("010-1234-1234")
+        .streetAddress("서울시 강남구 백양대로 123-12")
+        .longitude(123.12312)
+        .latitude(23.131)
+        .memberType(memberType)
+        .profileImage("/image/test/1")
+        .build();
+
+    return RestAssured
+        .given().body(request).contentType(ContentType.JSON)
+        .when().post("/members")
+        .then().extract().as(MemberDto.class);
   }
 }

--- a/src/test/java/com/example/wegather/member/domain/vo/PasswordTest.java
+++ b/src/test/java/com/example/wegather/member/domain/vo/PasswordTest.java
@@ -1,0 +1,47 @@
+package com.example.wegather.member.domain.vo;
+
+import static com.example.wegather.global.Message.Error.PASSWORD_RULE_VIOLATION;
+import static com.example.wegather.global.Message.Error.USERNAME_RULE_VIOLATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PasswordTest {
+  @Test
+  @DisplayName("비밀번호 생성에 성공합니다.")
+  void createPasswordSuccessfully() {
+    String password = "test1";
+
+    Password result = Password.of(password);
+
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  @DisplayName("비밀번호가 4자 미만이어서 생성에 실패합니다.")
+  void createPasswordFailBecauseOfLessThanFour() {
+    // given
+    String password = "tes";
+
+    // when // then
+    assertThatThrownBy(() -> {
+      Password result = Password.of(password);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(PASSWORD_RULE_VIOLATION);
+  }
+
+  @Test
+  @DisplayName("비밀번호가 12자 초과이어서 생성에 실패합니다.")
+  void createPasswordFailBecauseOfGreaterThanTwelve() {
+    // given
+    String password = "testtesttest1";
+
+    // when // then
+    assertThatThrownBy(() -> {
+      Password result = Password.of(password);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(PASSWORD_RULE_VIOLATION);
+  }
+}

--- a/src/test/java/com/example/wegather/member/domain/vo/UsernameTest.java
+++ b/src/test/java/com/example/wegather/member/domain/vo/UsernameTest.java
@@ -1,0 +1,60 @@
+package com.example.wegather.member.domain.vo;
+
+import static com.example.wegather.global.Message.Error.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UsernameTest {
+
+  @Test
+  @DisplayName("회원 아이디 생성에 성공합니다.")
+  void createUsernameSuccessfully() {
+    String username = "test1";
+
+    Username result = Username.of(username);
+
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  @DisplayName("회원아이디가 4자 미만이어서 생성에 실패합니다.")
+  void createUsernameFailBecauseOfLessThanFour() {
+    // given
+    String username = "tes";
+
+    // when // then
+    assertThatThrownBy(() -> {
+      Username result = Username.of(username);
+    }).isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(USERNAME_RULE_VIOLATION);
+  }
+
+  @Test
+  @DisplayName("회원아이디가 12자 초과이어서 생성에 실패합니다.")
+  void createUsernameFailBecauseOfGreaterThanTwelve() {
+    // given
+    String username = "testtesttest1";
+
+    // when // then
+    assertThatThrownBy(() -> {
+      Username result = Username.of(username);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(USERNAME_RULE_VIOLATION);
+  }
+
+  @Test
+  @DisplayName("회원아이디에 대문자가 포함되어 생성에 실패합니다.")
+  void createUsernameFailBecauseOfUpperCase() {
+    // given
+    String username = "Test1";
+
+    // when // then
+    assertThatThrownBy(() -> {
+      Username result = Username.of(username);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(USERNAME_RULE_VIOLATION);
+  }
+
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
관심사 도메인 구현

**TO-BE**
회원 엔티티 구현
- 회원 엔티티 구현을 위한 vo 추가
- 회원 엔티티 구현
- 회원 추가, 조회, 삭제 기능 추가
- 통합테스트 추가

## 질문사항
안녕하세요! 리뷰어님! 
현재 회원-관심사 중간테이블을 따로 두지 않고, 회원에서 관심사 정보를 담고 있으며, full-text-search를 활용하려고 합니다. 이럴때는 어떤방식으로 데이터를 저장하나요? 지나가는 말씀으로 json형식으로 저장한다고 해주셨던 것 같은데 json 형식( {key:value}) 그대로 컬럼에 저장을 하는 건가요? 만약 데이터를 추가한다고하면 이 json을 list로 역직렬화 해서 add한 후 직렬화해서 저장하는 건가요?

### 테스트
- [x] 통합테스트
